### PR TITLE
Checkstyle: have SAME_PACKAGE imports appear before third-party imports

### DIFF
--- a/google-checks.xml
+++ b/google-checks.xml
@@ -167,9 +167,9 @@
         </module>
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="CustomImportOrder">
-            <property name="specialImportsRegExp" value="com.google"/>
+            <property name="specialImportsRegExp" value="^javax\."/>
             <property name="sortImportsInGroupAlphabetically" value="true"/>
-            <property name="customImportOrderRules" value="STATIC###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE"/>
+            <property name="customImportOrderRules" value="STATIC###SAME_PACKAGE(2)###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS"/>
         </module>
         <module name="MethodParamPad"/>
         <module name="OperatorWrap">


### PR DESCRIPTION
I modify the checkstyle config to have SAME_PACKAGE imports appear
before third-party imports. I think this better matches the intent of
the import ordering rules in the style guide.
https://google.github.io/styleguide/javaguide.html#s3.3.3-import-ordering-and-spacing
Especially since it says the `com.google` imports only appear after
static imports if the source file is in the `com.google` package space.