### PR TITLE
Adds versions rules

### DIFF
--- a/versions-rules.xml
+++ b/versions-rules.xml
@@ -22,4 +22,12 @@ limitations under the License.
     <ignoreVersion type="regex">.*-b[0-9]*</ignoreVersion>
     <ignoreVersion type="regex">.*-rc(-)?[0-9]*</ignoreVersion>
   </ignoreVersions>
+  <rules>
+    <!-- SendGrid 3 libraries are broken in App Engine standard environment -->
+    <rule groupId="com.sendgrid" artifactId="sendgrid-java" comparisonMethod="maven">
+      <ignoreVersions>
+        <ignoreVersion type="regex">3.*</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+  </rules>
 </ruleset>

--- a/versions-rules.xml
+++ b/versions-rules.xml
@@ -1,0 +1,25 @@
+<!--
+Copyright 2016 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<ruleset comparisonMethod="maven"
+         xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 http://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+  <ignoreVersions>
+    <ignoreVersion type="regex">.*-alpha.*</ignoreVersion>
+    <ignoreVersion type="regex">.*-beta.*</ignoreVersion>
+    <ignoreVersion type="regex">.*-b[0-9]*</ignoreVersion>
+    <ignoreVersion type="regex">.*-rc(-)?[0-9]*</ignoreVersion>
+  </ignoreVersions>
+</ruleset>


### PR DESCRIPTION
When running, set the rules for the version updater with a parameter like this:

    -Dmaven.version.rules=file://$(pwd)/java-repo-tools/versions-rules.xml

Relative URIs don't seem to be supported, so this seems to be the only way to
pass in special rules like this.