### PR TITLE
Ignore public_draft versions of packages.

### DIFF
--- a/versions-rules.xml
+++ b/versions-rules.xml
@@ -21,6 +21,7 @@ limitations under the License.
     <ignoreVersion type="regex">.*-beta.*</ignoreVersion>
     <ignoreVersion type="regex">.*-b[0-9]*</ignoreVersion>
     <ignoreVersion type="regex">.*-pre.*</ignoreVersion>
+    <ignoreVersion type="regex">.*public_draft</ignoreVersion>
     <ignoreVersion type="regex">.*-rc(-)?[0-9]*</ignoreVersion>
   </ignoreVersions>
   <rules>


### PR DESCRIPTION
The version updater was getting confused by this package:
https://mvnrepository.com/artifact/javax.servlet/jsp-api/2.0.public_draft