### PR TITLE
Ignore Jetty for version updates.

### DIFF
--- a/versions-rules.xml
+++ b/versions-rules.xml
@@ -25,6 +25,13 @@ limitations under the License.
     <ignoreVersion type="regex">.*-rc(-)?[0-9]*</ignoreVersion>
   </ignoreVersions>
   <rules>
+    <!-- Jetty should be manually, not automatically updated.
+         https://github.com/GoogleCloudPlatform/java-docs-samples/pull/323 -->
+    <rule groupId="org.eclipse.jetty" artifactId="jetty-maven-plugin" comparisonMethod="maven">
+      <ignoreVersions>
+        <ignoreVersion type="regex">.*</ignoreVersion>
+      </ignoreVersions>
+    </rule>
     <!-- SendGrid 3 libraries are broken in App Engine standard environment -->
     <rule groupId="com.sendgrid" artifactId="sendgrid-java" comparisonMethod="maven">
       <ignoreVersions>


### PR DESCRIPTION
The dpebot pulls this config from upstream every time, so we shouldn't have to update it in the other repos.

@lesv FYI.