### PR TITLE
Add Sonatype requirements in preparation for release.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ language: java
 jdk:
 - oraclejdk7
 - oraclejdk8
-script: mvn verify
+script: mvn clean verify && cd test && mvn clean verify
 after_success:
 - bash <(curl -s https://codecov.io/bash)
 branches:

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@ limitations under the License.
 
   <groupId>com.google.cloud.samples</groupId>
   <artifactId>shared-configuration</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<project>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.google.cloud.samples</groupId>
@@ -50,9 +50,10 @@ limitations under the License.
   </developers>
 
   <scm>
-    <connection>scm:git:git://github.com/GoogleCloudPlatform/java-repo-tools.git</connection>
-    <developerConnection>scm:git:ssh://github.com:GoogleCloudPlatform/java-repo-tools.git</developerConnection>
-    <url>http://github.com/GoogleCloudPlatform/java-repo-tools/tree/master</url>
+    <url>https://github.com/GoogleCloudPlatform/java-repo-tools</url>
+    <connection>scm:git:https://github.com/GoogleCloudPlatform/java-repo-tools.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/GoogleCloudPlatform/java-repo-tools.git</developerConnection>
+    <tag>v1.0.0</tag>
   </scm>
 
   <properties>
@@ -67,13 +68,7 @@ limitations under the License.
   <profiles>
     <!-- Code signing for release: http://stackoverflow.com/a/14869692/101923 -->
     <profile>
-      <id>release-sign-artifacts</id>
-      <activation>
-        <property>
-          <name>performRelease</name>
-          <value>true</value>
-        </property>
-      </activation>
+      <id>release</id>
       <build>
         <plugins>
           <plugin>
@@ -87,8 +82,21 @@ limitations under the License.
                 <goals>
                   <goal>sign</goal>
                 </goals>
+                <configuration>
+                  <executable>gpg2</executable>
+                </configuration>
               </execution>
             </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-release-plugin</artifactId>
+            <version>2.5.3</version>
+            <configuration>
+              <tagBase>scm:git:ssh://git@github.com/GoogleCloudPlatform/java-repo-tools.git</tagBase>
+              <tagNameFormat>v@{project.version}</tagNameFormat>
+              <releaseProfiles>release</releaseProfiles>
+            </configuration>
           </plugin>
         </plugins>
       </build>
@@ -96,21 +104,6 @@ limitations under the License.
   </profiles>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-release-plugin</artifactId>
-          <version>2.5.3</version>
-          <configuration>
-            <tagBase>https://svn.mycompany.com/repos/myapplication/releases</tagBase>
-            <tagBase>scm:git:ssh://github.com:GoogleCloudPlatform/java-repo-tools.git</tagBase>
-            <tagNameFormat>v@{project.version}</tagNameFormat>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-
     <plugins>
       <plugin>
         <!-- Unit tests -->
@@ -174,11 +167,6 @@ limitations under the License.
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-release-plugin</artifactId>
-        <inherited>false</inherited>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -15,11 +15,45 @@ limitations under the License.
 -->
 <project>
   <modelVersion>4.0.0</modelVersion>
-  <version>1.0.0</version>
 
-  <groupId>com.google.cloud</groupId>
+  <groupId>com.google.cloud.samples</groupId>
   <artifactId>shared-configuration</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
+
+  <name>${project.groupId}:${project.artifactId}</name>
+  <description>A shared configuration for Google Cloud samples. This defines
+    common plugins and their configurations for testing, maintenance, and style
+    checks.</description>
+  <url>https://github.com/GoogleCloudPlatform/java-repo-tools</url>
+
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Les Vogel</name>
+      <email>lesv@google.com</email>
+      <organization>Google Inc.</organization>
+      <organizationUrl>https://cloud.google.com</organizationUrl>
+    </developer>
+    <developer>
+      <name>Tim Swast</name>
+      <email>swast@google.com</email>
+      <organization>Google Inc.</organization>
+      <organizationUrl>https://cloud.google.com</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:git://github.com/GoogleCloudPlatform/java-repo-tools.git</connection>
+    <developerConnection>scm:git:ssh://github.com:GoogleCloudPlatform/java-repo-tools.git</developerConnection>
+    <url>http://github.com/GoogleCloudPlatform/java-repo-tools/tree/master</url>
+  </scm>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -30,11 +64,53 @@ limitations under the License.
     <maven>3.1.0</maven>
   </prerequisites>
 
-  <modules>
-    <module>test</module>
-  </modules>
+  <profiles>
+    <!-- Code signing for release: http://stackoverflow.com/a/14869692/101923 -->
+    <profile>
+      <id>release-sign-artifacts</id>
+      <activation>
+        <property>
+          <name>performRelease</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.6</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>2.5.3</version>
+          <configuration>
+            <tagBase>https://svn.mycompany.com/repos/myapplication/releases</tagBase>
+            <tagBase>scm:git:ssh://github.com:GoogleCloudPlatform/java-repo-tools.git</tagBase>
+            <tagNameFormat>v@{project.version}</tagNameFormat>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
     <plugins>
       <plugin>
         <!-- Unit tests -->
@@ -98,6 +174,11 @@ limitations under the License.
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <inherited>false</inherited>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@ limitations under the License.
 
   <groupId>com.google.cloud.samples</groupId>
   <artifactId>shared-configuration</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.0.0</version>
   <packaging>pom</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -18,15 +18,15 @@ limitations under the License.
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.google.cloud</groupId>
+  <groupId>com.google.cloud.samples</groupId>
   <artifactId>shared-configuration-test</artifactId>
   <version>1.0</version>
   <packaging>jar</packaging>
 
   <parent>
     <artifactId>shared-configuration</artifactId>
-    <groupId>com.google.cloud</groupId>
-    <version>1.0.0</version>
+    <groupId>com.google.cloud.samples</groupId>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -26,7 +26,7 @@ limitations under the License.
   <parent>
     <artifactId>shared-configuration</artifactId>
     <groupId>com.google.cloud.samples</groupId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/test/src/test/java/com/google/cloud/samples/test/AppTest.java
+++ b/test/src/test/java/com/google/cloud/samples/test/AppTest.java
@@ -37,6 +37,6 @@ public class AppTest {
     App.main(new String[0]);
 
     String greeting = out.toString();
-    assertThat(greeting).named("greeting").contains("Hello World!");
+    assertThat(greeting).contains("Hello World!");
   }
 }


### PR DESCRIPTION
See: http://central.sonatype.org/pages/requirements.html

I'm attempting to package the parent pom in the group com.google.cloud.samples so that we can use it without all the pain of using git subtrees. I believe I now have permissions to push to this group based on https://issues.sonatype.org/browse/OSSRH-25441

@lesv Please take a look.