### PR TITLE
Second try at preparation for Sonatype release.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ language: java
 jdk:
 - oraclejdk7
 - oraclejdk8
-script: mvn verify
+script: mvn clean verify && cd test && mvn clean verify
 after_success:
 - bash <(curl -s https://codecov.io/bash)
 branches:

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@ limitations under the License.
 
   <groupId>com.google.cloud.samples</groupId>
   <artifactId>shared-configuration</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -13,13 +13,59 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<project>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <version>1.0.0</version>
 
-  <groupId>com.google.cloud</groupId>
+  <groupId>com.google.cloud.samples</groupId>
   <artifactId>shared-configuration</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
+
+  <name>${project.groupId}:${project.artifactId}</name>
+  <description>A shared configuration for Google Cloud samples. This defines
+    common plugins and their configurations for testing, maintenance, and style
+    checks.</description>
+  <url>https://github.com/GoogleCloudPlatform/java-repo-tools</url>
+
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Les Vogel</name>
+      <email>lesv@google.com</email>
+      <organization>Google Inc.</organization>
+      <organizationUrl>https://cloud.google.com</organizationUrl>
+    </developer>
+    <developer>
+      <name>Tim Swast</name>
+      <email>swast@google.com</email>
+      <organization>Google Inc.</organization>
+      <organizationUrl>https://cloud.google.com</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <url>https://github.com/GoogleCloudPlatform/java-repo-tools</url>
+    <connection>scm:git:https://github.com/GoogleCloudPlatform/java-repo-tools.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/GoogleCloudPlatform/java-repo-tools.git</developerConnection>
+    <tag>v1.0.0</tag>
+  </scm>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -30,11 +76,61 @@ limitations under the License.
     <maven>3.1.0</maven>
   </prerequisites>
 
-  <modules>
-    <module>test</module>
-  </modules>
+  <profiles>
+    <!-- Code signing for release: http://stackoverflow.com/a/14869692/101923 -->
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.6</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <!-- Plugins for release. See: http://central.sonatype.org/pages/apache-maven.html -->
+        <plugin>
+          <groupId>org.sonatype.plugins</groupId>
+          <artifactId>nexus-staging-maven-plugin</artifactId>
+          <version>1.6.7</version>
+          <extensions>true</extensions>
+          <configuration>
+            <serverId>ossrh</serverId>
+            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+            <stagingProfileId>2145015f0f5c04</stagingProfileId>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>2.5.3</version>
+          <configuration>
+            <tagBase>scm:git:ssh://git@github.com/GoogleCloudPlatform/java-repo-tools.git</tagBase>
+            <tagNameFormat>v@{project.version}</tagNameFormat>
+            <useReleaseProfile>false</useReleaseProfile>
+            <releaseProfiles>release</releaseProfiles>
+            <goals>deploy</goals>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <!-- Unit tests -->
@@ -98,6 +194,17 @@ limitations under the License.
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <!-- Release (not inherited) -->
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <inherited>false</inherited>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <inherited>false</inherited>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@ limitations under the License.
 
   <groupId>com.google.cloud.samples</groupId>
   <artifactId>shared-configuration</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.0.0</version>
   <packaging>pom</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -18,15 +18,15 @@ limitations under the License.
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.google.cloud</groupId>
+  <groupId>com.google.cloud.samples</groupId>
   <artifactId>shared-configuration-test</artifactId>
   <version>1.0</version>
   <packaging>jar</packaging>
 
   <parent>
     <artifactId>shared-configuration</artifactId>
-    <groupId>com.google.cloud</groupId>
-    <version>1.0.0</version>
+    <groupId>com.google.cloud.samples</groupId>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -26,7 +26,7 @@ limitations under the License.
   <parent>
     <artifactId>shared-configuration</artifactId>
     <groupId>com.google.cloud.samples</groupId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/test/src/test/java/com/google/cloud/samples/test/AppTest.java
+++ b/test/src/test/java/com/google/cloud/samples/test/AppTest.java
@@ -37,6 +37,6 @@ public class AppTest {
     App.main(new String[0]);
 
     String greeting = out.toString();
-    assertThat(greeting).named("greeting").contains("Hello World!");
+    assertThat(greeting).contains("Hello World!");
   }
 }


### PR DESCRIPTION
I was able to prepare this using the release plugin:

```
mvn -Prelease release:clean release:prepare
```

I believe that once I am added to the google-snapshots repository (https://issues.sonatype.org/browse/OSSRH-25451) I will be able to deploy using

```
mvn -Prelease release:perform
```

@lesv PTAL, though it should be pretty much the same as what you already reviewed.