### PR TITLE
Remove mailjet exception from versions updates.

### DIFF
--- a/versions-rules.xml
+++ b/versions-rules.xml
@@ -38,12 +38,6 @@ limitations under the License.
         <ignoreVersion type="regex">3.*</ignoreVersion>
       </ignoreVersions>
     </rule>
-    <!-- Mailjet made a breaking change between 4.0.1 and 4.0.4. -->
-    <rule groupId="com.mailjet" artifactId="mailjet-client" comparisonMethod="maven">
-      <ignoreVersions>
-        <ignoreVersion type="regex">4.*</ignoreVersion>
-      </ignoreVersions>
-    </rule>
     <!-- Logging v2 is a breaking change from v1, but samples are still v1. -->
     <rule groupId="com.google.apis" artifactId="google-api-services-logging" comparisonMethod="maven">
       <ignoreVersions>


### PR DESCRIPTION
Cedric updated the java-docs-samples mailjet sample to the latest version of the client library in https://github.com/GoogleCloudPlatform/java-docs-samples/pull/384. We should be able to track the latest release again.

@lesv ptal