### PR TITLE
Use properties for versions so they can be auto-updated.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,15 @@ limitations under the License.
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <!-- Plugin versions, so that they can get auto-updated by the versions plugin. -->
+    <maven-gpg-plugin-version>1.6</maven-gpg-plugin-version>
+    <codehaus-versions-maven-plugin-version>2.3</codehaus-versions-maven-plugin-version>
+    <jacoco-maven-plugin-version>0.7.7.201606060606</jacoco-maven-plugin-version>
+    <nexus-staging-maven-plugin-version>1.6.7</nexus-staging-maven-plugin-version>
+    <maven-failsafe-plugin-version>2.19.1</maven-failsafe-plugin-version>
+    <maven-surefire-plugin-version>2.19.1</maven-surefire-plugin-version>
+    <maven-checkstyle-plugin-version>2.17</maven-checkstyle-plugin-version>
+    <maven-release-plugin-version>2.5.3</maven-release-plugin-version>
   </properties>
 
   <prerequisites>
@@ -85,7 +94,7 @@ limitations under the License.
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>{$maven-gpg-plugin-version}</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -108,7 +117,7 @@ limitations under the License.
         <plugin>
           <groupId>org.sonatype.plugins</groupId>
           <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>1.6.7</version>
+          <version>${nexus-staging-maven-plugin-version}</version>
           <extensions>true</extensions>
           <configuration>
             <serverId>ossrh</serverId>
@@ -120,7 +129,7 @@ limitations under the License.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
-          <version>2.5.3</version>
+          <version>${maven-release-plugin-version}</version>
           <configuration>
             <tagBase>scm:git:ssh://git@github.com/GoogleCloudPlatform/java-repo-tools.git</tagBase>
             <tagNameFormat>v@{project.version}</tagNameFormat>
@@ -136,7 +145,7 @@ limitations under the License.
         <!-- Unit tests -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.19.1</version>
+        <version>${maven-surefire-plugin-version}</version>
         <configuration>
           <trimStackTrace>false</trimStackTrace>
         </configuration>
@@ -145,7 +154,7 @@ limitations under the License.
         <!-- Integration / system tests -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.19.1</version>
+        <version>${maven-failsafe-plugin-version}</version>
         <executions>
           <execution>
             <goals>
@@ -158,7 +167,7 @@ limitations under the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.17</version>
+        <version>${maven-checkstyle-plugin-version}</version>
         <configuration>
           <configLocation>google-checks.xml</configLocation>
           <consoleOutput>true</consoleOutput>
@@ -183,12 +192,12 @@ limitations under the License.
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
-        <version>2.2</version>
+        <version>${codehaus-versions-maven-plugin-version}</version>
       </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.7.6.201602180812</version>
+        <version>${jacoco-maven-plugin-version}</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
Should be exactly the same behavior as before. Only package upgraded was jacoco.

```
[INFO] Property ${maven-failsafe-plugin-version}: Leaving unchanged as 2.19.1
[INFO] Updated ${jacoco-maven-plugin-version} from 0.7.6.201602180812 to 0.7.7.201606060606
[INFO] Property ${maven-release-plugin-version}: Leaving unchanged as 2.5.3
[INFO] Property ${maven-surefire-plugin-version}: Leaving unchanged as 2.19.1
[INFO] Updated ${codehaus-versions-maven-plugin-version} from 2.2 to 2.3
[INFO] Property ${nexus-staging-maven-plugin-version}: Leaving unchanged as 1.6.7
[INFO] Property ${maven-checkstyle-plugin-version}: Leaving unchanged as 2.17
```

@lesv FYI