### PR TITLE
Exclude Guava

### DIFF
--- a/versions-rules.xml
+++ b/versions-rules.xml
@@ -1,5 +1,5 @@
 <!--
-Copyright 2016 Google Inc. All Rights Reserved.
+Copyright 2016 Google Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -35,6 +35,13 @@ limitations under the License.
          Version 5.x needs to be used for Java 7 support.
          https://github.com/GoogleCloudPlatform/java-docs-samples/pull/456#discussion_r92676013 -->
     <rule groupId="mysql" artifactId="mysql-connector-java" comparisonMethod="maven">
+      <ignoreVersions>
+        <ignoreVersion type="regex">.*</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+    <!-- Guava should not be automatically updated.
+         Version 21 requires Java 8 only. -->
+    <rule groupId="com.google.guava" artifactId="guava" comparisonMethod="maven">
       <ignoreVersions>
         <ignoreVersion type="regex">.*</ignoreVersion>
       </ignoreVersions>


### PR DESCRIPTION
Guava v21 is Java 8 only.
Also fix Copyright.