### PR TITLE
Lock out sendgrid updates for a bit

### DIFF
--- a/versions-rules.xml
+++ b/versions-rules.xml
@@ -68,7 +68,8 @@ limitations under the License.
     <!-- SendGrid 3 libraries are broken in App Engine standard environment -->
     <rule groupId="com.sendgrid" artifactId="sendgrid-java" comparisonMethod="maven">
       <ignoreVersions>
-        <ignoreVersion type="regex">3.*</ignoreVersion>
+<!--         <ignoreVersion type="regex">3.*</ignoreVersion> -->
+        <ignoreVersion type="regex">.*</ignoreVersion> <!-- Lock it for now - until we can updade and test updates -->
       </ignoreVersions>
     </rule>
 


### PR DESCRIPTION
We seem to have missed 2 versions, this should be retested.