### PR TITLE
adding LLC (>= 2018 licenses use Google LLC)

### DIFF
--- a/checkstyle-config/src/main/resources/LICENSE.txt
+++ b/checkstyle-config/src/main/resources/LICENSE.txt
@@ -1,6 +1,6 @@
 ^/\*$
 ^<!--$
-^\W+\*?\W*Copyright 20\d\d Google Inc.$
+^\W+\*?\W*Copyright 20\d\d Google (Inc\.|LLC)$
 ^\W+\*?\W*$
 ^\W+\*?\W*Licensed under the Apache License, Version 2.0 \(the "License"\);$
 ^\W+\*?\W*you may not use this file except in compliance with the License.$


### PR DESCRIPTION
@dzlier-gcp , @lesv  FYI
We'd need to cut a release for this & update the sample repositories to make sure that samples added have the right entity name.

checkstyle currently fails w/ LLC
