### PR TITLE
Add failsafe report name suffix to write sponge logs for fusion.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,9 @@ limitations under the License.
             </goals>
           </execution>
         </executions>
+        <configuration>
+          <reportNameSuffix>sponge_log</reportNameSuffix>
+        </configuration>
       </plugin>
 
       <plugin> <!-- Style Check -->


### PR DESCRIPTION
Turns out there are more failsafe tests in getting-started-java than in java-docs-samples, so might as well have the suffix here for consistency.