### PR TITLE
Update ErrorProne for newer Java versions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,28 +144,24 @@ limitations under the License.
   <build>
     <plugins>
 
-      <plugin> <!-- Compile w/ Errorprone -->
+      <!-- Compile w/ ErrorProne (see https://errorprone.info) -->
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.6.2</version>
+        <version>3.8.0</version>
         <configuration>
-          <compilerId>javac-with-errorprone</compilerId>
-          <forceJavacCompilerUse>true</forceJavacCompilerUse>
+          <compilerArgs>
+            <arg>-XDcompilePolicy=simple</arg>
+            <arg>-Xplugin:ErrorProne</arg>
+          </compilerArgs>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+              <version>2.3.3</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-compiler-javac-errorprone</artifactId>
-            <version>2.8.2</version>
-          </dependency>
-          <!-- override plexus-compiler-javac-errorprone's dependency on
-               Error Prone with the latest version -->
-          <dependency>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>error_prone_core</artifactId>
-            <version>2.0.21</version>
-          </dependency>
-        </dependencies>
       </plugin>
 
       <plugin> <!-- Unit Tests -->

--- a/pom.xml
+++ b/pom.xml
@@ -90,10 +90,12 @@ limitations under the License.
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <javac.version>9+181-r4173-1</javac.version>
   </properties>
 
   <profiles>
-    <profile> <!-- Code signing for release: http://stackoverflow.com/a/14869692/101923 -->
+    <!-- Code signing for release: http://stackoverflow.com/a/14869692/101923 -->
+    <profile>
       <id>release</id>
       <build>
         <plugins>
@@ -136,6 +138,28 @@ limitations under the License.
             </executions>
           </plugin>
 
+        </plugins>
+      </build>
+    </profile>
+
+    <!-- using github.com/google/error-prone-javac is required when running on JDK 8 -->
+    <profile>
+      <id>jdk8</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <fork>true</fork>
+              <compilerArgs combine.children="append">
+                <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${javac.version}/javac-${javac.version}.jar</arg>
+              </compilerArgs>
+            </configuration>
+          </plugin>
         </plugins>
       </build>
     </profile>


### PR DESCRIPTION
One of the compiler args seems to be required for Java11:
```
            <arg>-XDcompilePolicy=simple</arg>
            <arg>-Xplugin:ErrorProne</arg>
```