### PR TITLE
Update Checkstyle plugin + dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,7 @@ limitations under the License.
       <plugin> <!-- Style Check -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.17</version>
+        <version>3.0.0</version>
         <configuration>
           <configLocation>google-checks.xml</configLocation>
           <headerLocation>LICENSE.txt</headerLocation>
@@ -239,7 +239,7 @@ limitations under the License.
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.1</version>
+            <version>8.19</version>
           </dependency>
         </dependencies>
         <executions>

--- a/third_party/checkstyle/METADATA
+++ b/third_party/checkstyle/METADATA
@@ -14,6 +14,6 @@ third_party {
     value: "https://github.com/checkstyle/checkstyle"
   }
   version: "8.0.1"
-  last_upgrade_date { year: 2017 month: 8 day: 10 }
-  local_modifications: "SuppressWarningsFilter & SuppressionCommentFilter"
+  last_upgrade_date { year: 2019 month: 4 day: 15 }
+  local_modifications: "RegexpHeader, SuppressWarningsFilter, and SuppressionCommentFilter"
 }

--- a/third_party/checkstyle/google_checks.xml
+++ b/third_party/checkstyle/google_checks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-    "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-    "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
+  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+  "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!--
     Checkstyle configuration that checks the Google coding conventions from Google Java Style
@@ -16,27 +16,29 @@
  -->
 
 <module name="Checker">
+  <!-- Checks for License -->
+  <module name="RegexpHeader">
+    <property name="headerFile" value="${checkstyle.header.file}"/>
+    <property name="multiLines" value="1,2,16,17"/>
+  </module>
+
   <property name="charset" value="UTF-8"/>
 
   <property name="severity" value="error"/>
 
   <property name="fileExtensions" value="java, properties, xml"/>
+  <!-- Excludes all 'module-info.java' files              -->
+  <!-- See https://checkstyle.org/config_filefilters.html -->
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="module\-info\.java$"/>
+  </module>
   <!-- Checks for whitespace                               -->
   <!-- See http://checkstyle.sf.net/config_whitespace.html -->
   <module name="FileTabCharacter">
     <property name="eachLine" value="true"/>
   </module>
 
-  <module name="SuppressWarningsFilter"/>
-
-  <!-- Checks for Apache License -->
-  <module name="RegexpHeader">
-    <property name="headerFile" value="${checkstyle.header.file}"/>
-    <property name="multiLines" value="1,2,16,17"/>
-  </module>
-
   <module name="TreeWalker">
-
     <!-- Allow silencing rules with annotations http://stackoverflow.com/a/22556386/101923 -->
     <module name="SuppressWarningsHolder"/>
     <!-- Allow silencing with comment http://stackoverflow.com/questions/4023185 -->
@@ -50,9 +52,9 @@
     <module name="IllegalTokenText">
       <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
       <property name="format"
-          value="\\u00(09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
+        value="\\u00(09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
       <property name="message"
-          value="Consider using special escape sequence instead of octal value or Unicode escaped value."/>
+        value="Consider using special escape sequence instead of octal value or Unicode escaped value."/>
     </module>
     <module name="AvoidEscapedUnicodeCharacters">
       <property name="allowEscapesForControlCharacters" value="true"/>
@@ -62,7 +64,7 @@
     <module name="LineLength">
       <property name="max" value="100"/>
       <property name="ignorePattern"
-          value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+        value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
     </module>
     <module name="AvoidStarImport"/>
     <module name="OneTopLevelClass"/>
@@ -70,30 +72,33 @@
     <module name="EmptyBlock">
       <property name="option" value="TEXT"/>
       <property name="tokens"
-          value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
+        value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
     </module>
     <module name="NeedBraces"/>
     <module name="LeftCurly"/>
     <module name="RightCurly">
       <property name="id" value="RightCurlySame"/>
       <property name="tokens"
-          value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_DO"/>
+        value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE,
+                    LITERAL_DO"/>
     </module>
     <module name="RightCurly">
       <property name="id" value="RightCurlyAlone"/>
       <property name="option" value="alone"/>
       <property name="tokens"
-          value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT"/>
+        value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
+                    INSTANCE_INIT"/>
     </module>
     <module name="WhitespaceAround">
       <property name="allowEmptyConstructors" value="true"/>
+      <property name="allowEmptyLambdas" value="true"/>
       <property name="allowEmptyMethods" value="true"/>
       <property name="allowEmptyTypes" value="true"/>
       <property name="allowEmptyLoops" value="true"/>
       <message key="ws.notFollowed"
-          value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
+        value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
       <message key="ws.notPreceded"
-          value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
+        value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
     </module>
     <module name="OneStatementPerLine"/>
     <module name="MultipleVariableDeclarations"/>
@@ -135,58 +140,63 @@
     <module name="PackageName">
       <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
       <message key="name.invalidPattern"
-          value="Package name ''{0}'' must match pattern ''{1}''."/>
+        value="Package name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="TypeName">
       <message key="name.invalidPattern"
-          value="Type name ''{0}'' must match pattern ''{1}''."/>
+        value="Type name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="MemberName">
       <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
       <message key="name.invalidPattern"
-          value="Member name ''{0}'' must match pattern ''{1}''."/>
+        value="Member name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="ParameterName">
       <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
       <message key="name.invalidPattern"
-          value="Parameter name ''{0}'' must match pattern ''{1}''."/>
+        value="Parameter name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="LambdaParameterName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+        value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="CatchParameterName">
       <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
       <message key="name.invalidPattern"
-          value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
+        value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="LocalVariableName">
       <property name="tokens" value="VARIABLE_DEF"/>
       <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
       <message key="name.invalidPattern"
-          value="Local variable name ''{0}'' must match pattern ''{1}''."/>
+        value="Local variable name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="ClassTypeParameterName">
       <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
       <message key="name.invalidPattern"
-          value="Class type name ''{0}'' must match pattern ''{1}''."/>
+        value="Class type name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="MethodTypeParameterName">
       <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
       <message key="name.invalidPattern"
-          value="Method type name ''{0}'' must match pattern ''{1}''."/>
+        value="Method type name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="InterfaceTypeParameterName">
       <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
       <message key="name.invalidPattern"
-          value="Interface type name ''{0}'' must match pattern ''{1}''."/>
+        value="Interface type name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="NoFinalizer"/>
     <module name="GenericWhitespace">
       <message key="ws.followed"
-          value="GenericWhitespace ''{0}'' is followed by whitespace."/>
+        value="GenericWhitespace ''{0}'' is followed by whitespace."/>
       <message key="ws.preceded"
-          value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
+        value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
       <message key="ws.illegalFollow"
-          value="GenericWhitespace ''{0}'' should followed by whitespace."/>
+        value="GenericWhitespace ''{0}'' should followed by whitespace."/>
       <message key="ws.notPreceded"
-          value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
+        value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
     </module>
     <module name="Indentation">
       <property name="basicOffset" value="2"/>
@@ -209,18 +219,21 @@
     </module>
     <module name="MethodParamPad"/>
     <module name="NoWhitespaceBefore">
-      <property name="tokens" value="COMMA, SEMI, POST_INC, POST_DEC, DOT, ELLIPSIS, METHOD_REF"/>
+      <property name="tokens"
+        value="COMMA, SEMI, POST_INC, POST_DEC, DOT, ELLIPSIS, METHOD_REF"/>
       <property name="allowLineBreaks" value="true"/>
     </module>
     <module name="ParenPad"/>
     <module name="OperatorWrap">
       <property name="option" value="NL"/>
       <property name="tokens"
-          value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR, METHOD_REF "/>
+        value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR,
+                    LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR, METHOD_REF "/>
     </module>
     <module name="AnnotationLocation">
       <property name="id" value="AnnotationLocationMostCases"/>
-      <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>
+      <property name="tokens"
+        value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>
     </module>
     <module name="AnnotationLocation">
       <property name="id" value="AnnotationLocationVariables"/>
@@ -231,13 +244,13 @@
     <module name="JavadocTagContinuationIndentation"/>
     <module name="SummaryJavadoc">
       <property name="forbiddenSummaryFragments"
-          value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
+        value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
     </module>
     <module name="JavadocParagraph"/>
     <module name="AtclauseOrder">
       <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
       <property name="target"
-          value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+        value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
     </module>
     <module name="JavadocMethod">
       <property name="scope" value="public"/>
@@ -251,7 +264,7 @@
     <module name="MethodName">
       <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
       <message key="name.invalidPattern"
-          value="Method name ''{0}'' must match pattern ''{1}''."/>
+        value="Method name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="SingleLineJavadoc">
       <property name="ignoreInlineTags" value="false"/>
@@ -261,5 +274,4 @@
     </module>
     <module name="CommentsIndentation"/>
   </module>
-
 </module>


### PR DESCRIPTION
`checkstyle:8.1` had a security vulnerability, updating it required a newer `maven-checkstyle-plugin`, and then I figured I should update the `google_checks.xml` to the most recent version while I was at it. 