### PR TITLE
Return to SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This package is meant to be used as a parent pom, so that [CheckStyle](https://g
     <parent>
         <groupId>com.google.cloud.samples</groupId>
         <artifactId>shared-configuration</artifactId>
-        <version>1.0.10</version>
+        <version>1.0.12</version>
     </parent>
 ```
 

--- a/checkstyle-config/pom.xml
+++ b/checkstyle-config/pom.xml
@@ -18,7 +18,7 @@ limitations under the License.
 
   <groupId>com.google.cloud.samples</groupId>
   <artifactId>checkstyle-configuration</artifactId>
-  <version>1.0.12</version>
+  <version>1.0.13-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>
@@ -57,7 +57,7 @@ limitations under the License.
     <url>https://github.com/GoogleCloudPlatform/java-repo-tools</url>
     <connection>scm:git:https://github.com/GoogleCloudPlatform/java-repo-tools.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/GoogleCloudPlatform/java-repo-tools.git</developerConnection>
-    <tag>v1.0.10</tag>
+    <tag>v1.0.13-snapshot</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@ limitations under the License.
 
   <groupId>com.google.cloud.samples</groupId>
   <artifactId>shared-configuration</artifactId>
-  <version>1.0.12</version>
+  <version>1.0.13-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>
@@ -61,7 +61,7 @@ limitations under the License.
     <connection>scm:git:git@github.com:GoogleCloudPlatform/java-repo-tools.git</connection>
     <developerConnection>scm:git:git@github.com:GoogleCloudPlatform/java-repo-tools.git</developerConnection>
     <url>git@github.com:GoogleCloudPlatform/java-repo-tools.git</url>
-    <tag>v1.0.12</tag>
+    <tag>v1.0.13-snapshot</tag>
   </scm>
 
   <distributionManagement>
@@ -222,12 +222,12 @@ limitations under the License.
           <dependency>
             <groupId>com.google.cloud.samples</groupId>
             <artifactId>checkstyle-configuration</artifactId>
-            <version>1.0.12</version>
+            <version>1.0.13-SNAPSHOT</version>
           </dependency>
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>[8.30,)</version>
+            <version>8.30</version>
           </dependency>
         </dependencies>
         <executions>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -26,7 +26,7 @@ limitations under the License.
   <parent>
     <artifactId>shared-configuration</artifactId>
     <groupId>com.google.cloud.samples</groupId>
-    <version>1.0.12</version>
+    <version>1.0.13-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 


### PR DESCRIPTION
Just before release
* Update README for the release
* Reset paths to -SNAPSHOT
* fix checkstyle version - [xxx,) versions appear unable to be pushed to maven.