### PR TITLE
Add imagemagick apt dependency

### DIFF
--- a/java-testing/Dockerfile
+++ b/java-testing/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update \
       python \
       openjdk-8-jdk \
       software-properties-common \
+      imagemagick \
     && update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java \
     && apt-get clean
 


### PR DESCRIPTION
Required for [`functions/imagemagick` samples](https://github.com/GoogleCloudPlatform/java-docs-samples/pull/2520)