### PR TITLE
Update spotBugsExcludeFilter.xml

### DIFF
--- a/checkstyle-config/src/main/resources/c.g.c.s/spotBugsExcludeFilter.xml
+++ b/checkstyle-config/src/main/resources/c.g.c.s/spotBugsExcludeFilter.xml
@@ -25,12 +25,38 @@ see https://spotbugs.readthedocs.io/en/stable/bugDescriptions.html
   xmlns="https://github.com/spotbugs/filter/3.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
-<Match>
-    <Or>
-      <!-- TODO: Remove once SpotBugs fully supports Java 11 (JENKINS-53720) -->
-      <!-- JDK 11 generates a different binary code than expected by SpotBugs -->
-      <!-- https://github.com/spotbugs/spotbugs/issues/756 -->
-      <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
-    </Or>
+  <Match>
+    <!-- TODO: Remove once SpotBugs fully supports Java 11 (JENKINS-53720) -->
+    <!-- JDK 11 generates a different binary code than expected by SpotBugs -->
+    <!-- https://github.com/spotbugs/spotbugs/issues/756 -->
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
+  </Match>
+  <!-- From https://github.com/GoogleCloudPlatform/java-repo-tools/issues/123 -->
+  <!-- https://github.com/GoogleCloudPlatform/java-docs-samples/pull/2630#issuecomment-612320968 -->
+  <!--      <Bug pattern="IMC_IMMATURE_CLASS_NO_TOSTRING" />-->
+  <!--      <Bug pattern="CRLF_INJECTION_LOGS" />-->
+  <!--      <Bug pattern="LI_LAZY_INIT_STATIC" />-->
+  <!--      <Bug pattern="DLS_DEAD_LOCAL_STORE" />-->
+
+  <Match>
+    <!-- https://github.com/spotbugs/spotbugs/issues/735 -->
+    <Bug pattern="UPM_UNCALLED_PRIVATE_METHOD"/>
+  </Match>
+  <Match>
+    <!-- https://github.com/spotbugs/spotbugs/issues/651 -->
+    <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
+  </Match>
+
+  <Match>
+    <!-- Samples uses this idiom a lot, so I'm turning it off -->
+    <Bug pattern="CLI_CONSTANT_LIST_INDEX"/>
+  </Match>
+  <Match>
+    <!-- https://github.com/spotbugs/spotbugs/issues/925 -->
+    <Bug pattern="PCOA_PARTIALLY_CONSTRUCTED_OBJECT_ACCESS"/>
+  </Match>
+  <Match>
+    <!-- https://github.com/spotbugs/spotbugs/issues/293 -->
+    <Bug pattern="OBL_UNSATISFIED_OBLIGATION"/>
   </Match>
 </FindBugsFilter>


### PR DESCRIPTION
Add a few exclusions:
* `RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE` - existing - codegen bug
* `UPM_UNCALLED_PRIVATE_METHOD` - probably SpotBug issue
* `NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE` - likely SpotBug issue
* `CLI_CONSTANT_LIST_INDEX` - style issue particular to our samples
* `OBL_UNSATISFIED_OBLIGATION` - issue for SQL clients

Fixes: #123 