### PR TITLE
Suppress AbbreviationAsWordInName for tests

### DIFF
--- a/checkstyle-config/src/main/resources/suppressions.xml
+++ b/checkstyle-config/src/main/resources/suppressions.xml
@@ -24,4 +24,7 @@ limitations under the License.
   <!-- Suppress checks for generated code. -->
   <suppress files="[/\\]target[/\\]" checks=".+"/>
   <suppress files=".*AutoValue_.*\.java$" checks=".+"/>
+
+  <!-- Suppress AbbreviationAsWordInName for tests -->
+  <suppress files=".*/src/test/java/.*\.java" checks="AbbreviationAsWordInName" />
 </suppressions>

--- a/test/src/test/java/com/google/cloud/samples/test/AppTest.java
+++ b/test/src/test/java/com/google/cloud/samples/test/AppTest.java
@@ -30,7 +30,7 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class AppTest {
-  @Test public void main_printsHelloWorld() {
+  @Test public void main_printsHelloWorldIT() {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     System.setOut(new PrintStream(out));
 


### PR DESCRIPTION
* Create a test that triggers things
* add a suppression rule that stops it. Fixes #201