### PR TITLE
feat(style checks): allow underscore lambda params

### DIFF
--- a/third_party/checkstyle/google_checks.xml
+++ b/third_party/checkstyle/google_checks.xml
@@ -203,7 +203,7 @@
         value="Parameter name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="LambdaParameterName">
-      <property name="format" value="^([a-z]([a-z0-9][a-zA-Z0-9]*)|_{2,})$"/>
+      <property name="format" value="^([a-z]([a-z0-9][a-zA-Z0-9]*)?|_{2,})$"/>
       <message key="name.invalidPattern"
         value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>
     </module>

--- a/third_party/checkstyle/google_checks.xml
+++ b/third_party/checkstyle/google_checks.xml
@@ -203,7 +203,7 @@
         value="Parameter name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="LambdaParameterName">
-      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <property name="format" value="^([a-z]([a-z0-9][a-zA-Z0-9]*)|_{2,})$"/>
       <message key="name.invalidPattern"
         value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>
     </module>


### PR DESCRIPTION
We should allow `__` to denote that a (required) lambda parameter is unused.

(I didn't do this for standard method parameters, as that seems overkill for our purposes. After all, no-argument _methods_ are allowed in Java - but no-argument _lambdas_ are not.)

As discussed in [this StackOverflow post](https://stackoverflow.com/questions/37597728/writing-a-lambda-expression-when-parameters-are-ignored-in-the-body).