### PR TITLE
chore: Prepare for 1.0.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Please ensure that samples function without this parent definition.
 
 ## USAGE
 
+### WARNING - CheckStyle currently requires Java 11
+
 ```bash
 mvn -P lint clean verify
 ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,13 +20,11 @@ From the root project folder, run the following command to release `checkstyle-c
 
     cd checkstyle-config
     mvn -P release clean verify deploy 
-    mvn -P release deploy 
 
 Next, use the following to release `shared-configuration`:
 
     cd ..
-    mvn -P release clean verify 
-    mvn -P release deploy 
+    mvn -P release clean verify deploy
 
 That will open, upload, close, and release.  The parent will need you to visit sonatype to close,
 and verify manually.

--- a/checkstyle-config/pom.xml
+++ b/checkstyle-config/pom.xml
@@ -18,7 +18,7 @@ limitations under the License.
 
   <groupId>com.google.cloud.samples</groupId>
   <artifactId>checkstyle-configuration</artifactId>
-  <version>1.0.24-SNAPSHOT</version>
+  <version>1.0.24</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@ limitations under the License.
 
   <groupId>com.google.cloud.samples</groupId>
   <artifactId>shared-configuration</artifactId>
-  <version>1.1.1-SNAPSHOT</version><!-- {x-version-update:shared-configuration:current} -->
+  <version>1.0.24</version><!-- {x-version-update:shared-configuration:current} -->
   <packaging>pom</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>
@@ -216,7 +216,7 @@ limitations under the License.
               <dependency>
                 <groupId>com.google.cloud.samples</groupId>
                 <artifactId>checkstyle-configuration</artifactId>
-                <version>1.0.24-SNAPSHOT</version>
+                <version>1.0.24</version>
               </dependency>
             </dependencies>
             <configuration>
@@ -306,7 +306,7 @@ limitations under the License.
               <dependency>
                 <groupId>com.google.cloud.samples</groupId>
                 <artifactId>checkstyle-configuration</artifactId>
-                <version>1.0.24-SNAPSHOT</version>
+                <version>1.0.24</version>
               </dependency>
               <dependency>
                 <groupId>com.puppycrawl.tools</groupId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -26,7 +26,7 @@ limitations under the License.
   <parent>
     <artifactId>shared-configuration</artifactId>
     <groupId>com.google.cloud.samples</groupId>
-    <version>1.1.1-SNAPSHOT</version><!-- {x-version-update:shared-configuration:current} -->
+    <version>1.0.24</version><!-- {x-version-update:shared-configuration:current} -->
     <relativePath>..</relativePath>
   </parent>
 

--- a/test/src/test/java/com/google/cloud/samples/test/AppTest.java
+++ b/test/src/test/java/com/google/cloud/samples/test/AppTest.java
@@ -30,13 +30,13 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class AppTest {
-  @Test public void main_printsHelloWorldIT() {
+  @Test public void main_printsHelloWorldIT() throws Exception {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
-    System.setOut(new PrintStream(out));
+    System.setOut(new PrintStream(out, true, "UTF-8"));
 
     App.main(new String[0]);
 
-    String greeting = out.toString();
+    String greeting = out.toString("UTF-8");
     assertThat(greeting).contains("Hello World!");
   }
 }


### PR DESCRIPTION
* fix 2 DM_DEFAULT_ENCODING problems in testing
* update README to mention it's Java 11 only
* update RELEASING to simplify
* Normal striking the -SNAPSHOT before release