### PR TITLE
fix(infra): update GitHub Action to current checkout and distribution

### DIFF
--- a/.github/workflows/onpush.yml
+++ b/.github/workflows/onpush.yml
@@ -11,15 +11,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
+          cache: 'maven'
       - name: Build & Install checkstyle-config
-        run: cd checkstyle-config && mvn -B clean install && cd ..
+        run: mvn -B clean install
+        working-directory: checkstyle-config
+        
       - name: Build root
         run: mvn -B clean verify
+        
       - name: Test lint
-        run: cd test && mvn -B -P lint clean verify
+        run: mvn -B -P lint clean verify
+        working-directory: test


### PR DESCRIPTION
ci: update GitHub Action versions and optimize Maven build

- Bump actions/checkout and actions/setup-java
- Switch from deprecated 'adopt' to 'temurin' distribution
- Enable Maven caching to improve build performance
- Use working-directory parameter for cleaner step execution